### PR TITLE
Add demo examples to start and stop service instances

### DIFF
--- a/demo_finish_service_workflow.py
+++ b/demo_finish_service_workflow.py
@@ -1,0 +1,62 @@
+"""
+This script retrieves and manages active PSA service instances in the ProActive Scheduler.
+
+Steps:
+1. Initialize the ProActive gateway for communication.
+2. Retrieve all active PSA service instances.
+3. Extract relevant details, including:
+   - `instance_id`
+   - `user_name`
+   - `endpoint`
+   - `INSTANCE_NAME`
+4. Display available instance IDs and prompt the user to select one for termination.
+5. Validate user input:
+   - If valid, finish the selected service instance.
+   - If invalid, prompt again until a correct ID is entered.
+6. Close the connection to the ProActive Scheduler.
+
+Ensures efficient instance management with interactive selection and error handling.
+"""
+
+from proactive import getProActiveGateway
+import json
+
+# Initialize the ProActive gateway
+gateway = getProActiveGateway()
+
+instances = gateway.getProactiveRestApi().get_active_service_instances()
+
+# Get instances info
+instances_info = {
+    str(instance["instance_id"]): {  # Convert instance_id to string for easy comparison
+        "instance_id": instance["instance_id"],
+        "user_name": instance["user_name"],
+        "endpoint": instance["deployments"][0]["endpoint"].get("proxyfiedUrl") or instance["deployments"][0]["endpoint"].get("url"),
+        "INSTANCE_NAME": instance["variables"].get("INSTANCE_NAME", "N/A")
+    }
+    for instance in instances
+}
+
+# Show available instance IDs
+available_instance_ids = list(instances_info.keys())
+print("\nAvailable Instance IDs:", ", ".join(available_instance_ids))
+
+while True:
+    user_input = input("\nEnter the INSTANCE_ID of the service instance you want to stop: ").strip()
+    
+    if user_input in instances_info:
+        selected_instance = instances_info[user_input]
+        print("\n[INFO] Selected Instance Details:")
+        print(selected_instance)
+
+        # Finish service instance
+        print("Finishing Service with instance id...")
+        gateway.finishPSAServiceInstance(user_input)
+        break
+    else:
+        print(f"[ERROR] Invalid instance_id. Please choose from: {', '.join(available_instance_ids)}")
+
+
+# Cleanup
+gateway.close()
+print("Disconnected and finished.")

--- a/demo_start_service_workflow.py
+++ b/demo_start_service_workflow.py
@@ -1,0 +1,56 @@
+"""
+This script submits a PSA workflow from the ProActive catalog to the scheduler and retrieves its execution details.
+
+Steps:
+1. Initialize the ProActive gateway and REST API for interaction.
+2. Ask the user for bucket and workflow name via command-line input.
+3. Submit the workflow using `startPSAWorkflowFromCatalog()`, retrieving:
+   - `job_id`: The submitted job ID.
+   - `instance_id`: The created service instance ID.
+   - `service_job_id`: The running service’s job ID.
+   - `endpoint`: The service endpoint URL.
+   - `service_description`: Workflow metadata.
+4. Check execution success:
+   - Print job details if successful.
+   - Display an error and exit if failed.
+5. Close the connection to the ProActive Scheduler.
+
+Ensures efficient workflow execution with structured error handling and resource management.
+"""
+
+from proactive import getProActiveGateway, ProactiveRestApi
+import sys
+
+# Initialize the ProActive gateway
+gateway = getProActiveGateway()
+proactive_rest_api = ProactiveRestApi()
+
+# Ask the user for bucket and workflow names
+workflow_name = input("Enter the name of the service you want to launch: ").strip()
+bucket_name = input("Enter the bucket name containing the service: ").strip()
+
+# Start the workflow
+workflow_variables = {}
+try:
+    job_id, instance_id, service_job_id, endpoint, service_description = gateway.startPSAWorkflowFromCatalog(
+        bucket_name, workflow_name, workflow_variables
+    )
+except Exception as e:
+    print(f"\n[ERROR] Exception occurred while starting the workflow: {e}")
+    gateway.close()
+    sys.exit(1)
+
+# Check if the workflow started successfully
+if instance_id:
+    print("\n[INFO] Workflow Started Successfully!")
+    print(f"JOB_ID: {job_id}")
+    print(f"INSTANCE_ID: {instance_id}")
+    print(f"ENDPOINT_URL: {endpoint}")
+else:
+    print(f"\n[ERROR] Failed to start workflow '{workflow_name}' in bucket '{bucket_name}'. Check if bucket_name and/or workflow_name are valid.")
+    gateway.close()
+    sys.exit(1)
+
+# Cleanup
+gateway.close()
+print("\n[INFO] Disconnected and finished.")


### PR DESCRIPTION
In this PR: two new demo files are added that guide the user how to start a service instance (demo_start_service_workflow.py) and how to stop a service instance (demo_finish_service_workflow.py)